### PR TITLE
Add Flask service health dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Service Health Monitoring App
+
+This simple Flask application displays the health status of various services used by an MSP on a single dashboard page. It polls a set of status URLs and shows the current state, refreshing automatically on the page.
+
+## Features
+
+- Dashboard web page with live status updates
+- Background thread that checks services every minute
+- Test mode that generates random status results without making network requests
+
+## Setup
+
+1. Ensure Python 3.8+ and `pip` are installed on your Ubuntu server.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Run the server:
+   ```bash
+   python app.py
+   ```
+4. Open `http://localhost:8000` in your browser to view the dashboard.
+
+## Environment Variables
+
+- `TEST_MODE=1` – Do not make real HTTP requests and instead use random statuses. Useful if the server does not have internet access or while developing.
+
+## Adding Services
+
+Edit the `SERVICES` dictionary in `app.py` to change or add service status URLs. Each entry should map the display name to a URL that returns HTTP `200` when the service is healthy.
+
+## Disclaimer
+
+The built-in checks are simplistic and may not reflect the real status of each provider. For production use, replace `check_service` with logic specific to each service's official status API.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,74 @@
+import os
+import random
+import threading
+import time
+from datetime import datetime
+
+from flask import Flask, jsonify, render_template
+import requests
+
+app = Flask(__name__)
+
+SERVICES = {
+    "Microsoft 365": "https://status.office.com",
+    "Microsoft Exchange": "https://status.office.com",
+    "ProofPoint": "https://status.proofpoint.com",
+    "SentinelOne": "https://status.sentinelone.com",
+    "Duo Security": "https://status.duo.com",
+    "Verizon Wireless (South Florida)": "https://www.verizon.com/support/status/",
+    "AT&T Internet (South Florida)": "https://www.att.com/outages/",
+    "Xfinity Internet (South Florida)": "https://www.xfinity.com/support/service-status",
+    "ConnectWise Backup (Skykick)": "https://status.connectwise.com",
+    "Ring Central": "https://status.ringcentral.com",
+    "ConnectWise Control": "https://status.screenconnect.com",
+    "Webroot": "https://status.webroot.com",
+    "iDrive": "https://status.idrive.com",
+}
+
+status_cache = {name: "Unknown" for name in SERVICES}
+
+# If TEST_MODE is set, we will not make real HTTP requests
+TEST_MODE = os.getenv("TEST_MODE", "0") == "1"
+
+
+def check_service(name, url):
+    """Check the given service URL."""
+    if TEST_MODE:
+        return random.choice(["Operational", "Issues Detected"])
+    try:
+        resp = requests.get(url, timeout=5)
+        if resp.status_code == 200:
+            return "Operational"
+        return f"HTTP {resp.status_code}"
+    except Exception as exc:
+        return f"Error: {exc}"
+
+
+def update_statuses():
+    while True:
+        for name, url in SERVICES.items():
+            status_cache[name] = check_service(name, url)
+        time.sleep(60)  # update every minute
+
+
+def start_background_thread():
+    thread = threading.Thread(target=update_statuses, daemon=True)
+    thread.start()
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/api/status")
+def api_status():
+    return jsonify({
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "services": status_cache,
+    })
+
+
+if __name__ == "__main__":
+    start_background_thread()
+    app.run(host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+requests

--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,22 @@
+async function fetchStatus() {
+    try {
+        const resp = await axios.get('/api/status');
+        const tbody = document.querySelector('#status-table tbody');
+        tbody.innerHTML = '';
+        for (const [name, status] of Object.entries(resp.data.services)) {
+            const row = document.createElement('tr');
+            const nameCell = document.createElement('td');
+            nameCell.textContent = name;
+            const statusCell = document.createElement('td');
+            statusCell.textContent = status;
+            row.appendChild(nameCell);
+            row.appendChild(statusCell);
+            tbody.appendChild(row);
+        }
+    } catch (err) {
+        console.error('Failed to fetch status:', err);
+    }
+}
+
+fetchStatus();
+setInterval(fetchStatus, 30000); // refresh every 30 seconds

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Service Health Dashboard</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="bg-light">
+<div class="container py-4">
+    <h1 class="mb-4">Service Health Dashboard</h1>
+    <table class="table table-bordered" id="status-table">
+        <thead class="table-light">
+        <tr>
+            <th>Service</th>
+            <th>Status</th>
+        </tr>
+        </thead>
+        <tbody>
+        <!-- Rows will be inserted here -->
+        </tbody>
+    </table>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/axios@1.5.0/dist/axios.min.js"></script>
+<script src="/static/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- set up minimal Flask app
- add index page and JS for status updates
- include requirement and README instructions

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68520ed0f4208327a11150467bef6d57